### PR TITLE
Remove explicit pandas dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-pandas>=1.2.1
 dimod>=0.10.7
 dwave-system>=1.10.0
 pandas-datareader>=0.10.0


### PR DESCRIPTION
Installing `pandas-datareader` will also install `pandas`