### PR TITLE
Fix failing CircleCI tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ dimod~=0.12
 dwave-cloud-client>=0.14.1
 dwave-system~=1.34
 matplotlib~=3.10
-pandas~=3.0
+pandas~=2.3
 pandas-datareader~=0.10
 setuptools~=81.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@ dimod~=0.12
 dwave-cloud-client>=0.14.1
 dwave-system~=1.34
 matplotlib~=3.10
+pandas~=3.0
 pandas-datareader~=0.10
 setuptools~=81.0

--- a/src/utils.py
+++ b/src/utils.py
@@ -49,7 +49,8 @@ def clean_stock_data(df: pd.DataFrame, col_name: str) -> pd.DataFrame:
 
     monthly_stocks = monthly_stocks.set_index("Date")
 
-    monthly_stocks[col_name] = monthly_stocks[col_name].str.replace("$", "").astype("float")
+    if monthly_stocks[col_name].dtype == "str" or monthly_stocks[col_name].dtype == "object":
+        monthly_stocks[col_name] = monthly_stocks[col_name].str.replace("$", "").astype("float")
 
     return monthly_stocks
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -49,8 +49,7 @@ def clean_stock_data(df: pd.DataFrame, col_name: str) -> pd.DataFrame:
 
     monthly_stocks = monthly_stocks.set_index("Date")
 
-    if monthly_stocks[col_name].dtype == "str":
-        monthly_stocks[col_name] = monthly_stocks[col_name].str.replace("$", "").astype("float")
+    monthly_stocks[col_name] = monthly_stocks[col_name].str.replace("$", "").astype("float")
 
     return monthly_stocks
 


### PR DESCRIPTION
In pandas < 3 monthly_stocks[col_name].dtype is type object whereas it's type str in > 3. This is why tests were running fine locally but not in CircleCI as CircleCI was using pandas 2.3.3